### PR TITLE
fix migrations on development environment

### DIFF
--- a/src/Equinox.UI.Site/project.json
+++ b/src/Equinox.UI.Site/project.json
@@ -63,7 +63,10 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true
+    "preserveCompilationContext": true,
+    "copyToOutput": {
+      "include": [ "appsettings.json" ]
+    }
   },
 
   "runtimeOptions": {


### PR DESCRIPTION
There is a issue when you try to run the initial migrations. It presents a error message saying that the project.json file couldnt be found at the \bin\Debug folder. This change fixes that.