### PR TITLE
Adding extensions and separating entity configuration for better code d…

### DIFF
--- a/src/Equinox.Infra.Data/Context/EquinoxContext.cs
+++ b/src/Equinox.Infra.Data/Context/EquinoxContext.cs
@@ -1,5 +1,7 @@
 ﻿using System.IO;
 using Equinox.Domain.Models;
+using Equinox.Infra.Data.Mappings;
+using Equinox.Infra.Data.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 
@@ -11,22 +13,8 @@ namespace Equinox.Infra.Data.Context
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Customer>()
-                .Property(c => c.Id)
-                .HasColumnName("Id");
-
-            modelBuilder.Entity<Customer>()
-                .Property(c => c.Name)
-                .HasColumnType("varchar(100)")
-                .HasMaxLength(100)
-                .IsRequired();
-
-            modelBuilder.Entity<Customer>()
-                .Property(c => c.Email)
-                .HasColumnType("varchar(100)")
-                .HasMaxLength(11)
-                .IsRequired();
-            
+            modelBuilder.AddConfiguration(new CustomerMap());
+                        
             base.OnModelCreating(modelBuilder);
         }
 

--- a/src/Equinox.Infra.Data/Context/EventStoreSQLContext.cs
+++ b/src/Equinox.Infra.Data/Context/EventStoreSQLContext.cs
@@ -1,7 +1,10 @@
 ﻿using System.IO;
 using Equinox.Domain.Core.Events;
+using Equinox.Infra.Data.Mappings;
+using Equinox.Infra.Data.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+
 
 namespace Equinox.Infra.Data.Context
 {
@@ -11,14 +14,7 @@ namespace Equinox.Infra.Data.Context
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<StoredEvent>()
-                .Property(c => c.Timestamp)
-                .HasColumnName("CreationDate");
-
-            modelBuilder.Entity<StoredEvent>()
-                .Property(c => c.MessageType)
-                .HasColumnName("Action")
-                .HasColumnType("varchar(100)");
+            modelBuilder.AddConfiguration(new StoredEventMap());
 
             base.OnModelCreating(modelBuilder);
         }

--- a/src/Equinox.Infra.Data/Extensions/EntityTypeConfiguration.cs
+++ b/src/Equinox.Infra.Data/Extensions/EntityTypeConfiguration.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Equinox.Infra.Data.Extensions
+{
+    
+    public abstract class EntityTypeConfiguration<TEntity> where TEntity : class
+    {
+        public abstract void Map(EntityTypeBuilder<TEntity> builder);
+    }
+
+
+}

--- a/src/Equinox.Infra.Data/Extensions/ModelBuilderExtensions.cs
+++ b/src/Equinox.Infra.Data/Extensions/ModelBuilderExtensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equinox.Infra.Data.Extensions
+{
+    public static class ModelBuilderExtensions
+    {
+            public static void AddConfiguration<TEntity>(this ModelBuilder modelBuilder, EntityTypeConfiguration<TEntity> configuration) where TEntity : class
+            {
+                configuration.Map(modelBuilder.Entity<TEntity>());
+            }
+    }
+}

--- a/src/Equinox.Infra.Data/Mappings/CustomerMap.cs
+++ b/src/Equinox.Infra.Data/Mappings/CustomerMap.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Equinox.Domain.Models;
+using Equinox.Infra.Data.Extensions;
+
+
+namespace Equinox.Infra.Data.Mappings
+{    
+    public class CustomerMap : EntityTypeConfiguration<Customer>
+    {
+        public override void Map(EntityTypeBuilder<Customer> builder)
+        {
+            builder.Property(c => c.Id)
+                .HasColumnName("Id");
+
+            builder.Property(c => c.Name)
+                .HasColumnType("varchar(100)")
+                .HasMaxLength(100)
+                .IsRequired();
+
+            builder.Property(c => c.Email)
+                .HasColumnType("varchar(100)")
+                .HasMaxLength(11)
+                .IsRequired();   
+        }
+    }
+}

--- a/src/Equinox.Infra.Data/Mappings/StoredEventMap.cs
+++ b/src/Equinox.Infra.Data/Mappings/StoredEventMap.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Equinox.Infra.Data.Extensions;
+using Equinox.Domain.Core.Events;
+
+
+namespace Equinox.Infra.Data.Mappings
+{    
+    public class StoredEventMap : EntityTypeConfiguration<StoredEvent>
+    {
+        public override void Map(EntityTypeBuilder<StoredEvent> builder)
+        {
+            builder.Property(c => c.Timestamp)
+                .HasColumnName("CreationDate");
+
+            builder.Property(c => c.MessageType)
+                .HasColumnName("Action")
+                .HasColumnType("varchar(100)");
+  
+        }
+    }
+}


### PR DESCRIPTION
Hi Eduardo,

How Entity Framework Core don't implement the class EntityTypeConfiguration and the possibility of add configuration by modelBuilder. I implemented a solution for this problem using extension methods.


I hope you enjoy!

