### PR TITLE
Validating if user has rights based on claims.

### DIFF
--- a/src/Equinox.Infra.CrossCutting.Identity/Authorization/ClaimsRequirementHandler.cs
+++ b/src/Equinox.Infra.CrossCutting.Identity/Authorization/ClaimsRequirementHandler.cs
@@ -10,13 +10,11 @@ namespace Equinox.Infra.CrossCutting.Identity.Authorization
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context,
                                                        ClaimRequirement requirement)
         {
-
-            var claim = context.User.Claims.FirstOrDefault(c => c.Type == requirement.ClaimName);
-            if (claim != null && claim.Value.Contains(requirement.ClaimValue))
+            if (context.User.Claims.Any(c => c.Value.Contains(requirement.ClaimValue)))
             {
                 context.Succeed(requirement);
             }
-
+            
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
Using `.FirstOrDefault()` we are just looking at the first item inside the list of claims, in order to verify all Claims it is better to use `.Any()` instead.