### PR TITLE
Fixing EntityFramework DbContext injection

### DIFF
--- a/src/Equinox.Infra.CrossCutting.IoC/NativeInjectorBootStrapper.cs
+++ b/src/Equinox.Infra.CrossCutting.IoC/NativeInjectorBootStrapper.cs
@@ -54,12 +54,12 @@ namespace Equinox.Infra.CrossCutting.IoC
             // Infra - Data
             services.AddScoped<ICustomerRepository, CustomerRepository>();
             services.AddScoped<IUnitOfWork, UnitOfWork>();
-            services.AddScoped<EquinoxContext>();
+            services.AddDbContext<EquinoxContext>();
 
             // Infra - Data EventSourcing
             services.AddScoped<IEventStoreRepository, EventStoreSQLRepository>();
             services.AddScoped<IEventStore, SqlEventStore>();
-            services.AddScoped<EventStoreSQLContext>();
+            services.AddDbContext<EventStoreSQLContext>();
 
             // Infra - Identity Services
             services.AddTransient<IEmailSender, AuthEmailMessageSender>();


### PR DESCRIPTION
Fix an error occurred when trying to generate a migration with command:
`add-migration Test -Context EquinoxContext` or `add-migration Test -Context EventStoreSQLContext`
_DefaultProject:_ Equinox.Infra.Data
_StartupProject:_ Equinox.Services.Api

as seen below:
`Unable to create an object of type 'EquinoxContext'. For the different patterns supported at design time, see https://go.microsoft.com/fwlink/?linkid=851728`

Fixed changing `services.AddScoped<EquinoxContext>();` and `services.AddScoped<EventStoreSQLContext>();`
to
`services.AddDbContext<EquinoxContext>();` and `services.AddDbContext<EventStoreSQLContext>();`