### PR TITLE
Fix Migration

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "src", "test" ],
   "sdk": {
-    "version": "2.2.102"
+    "version": "2.2.300"
   }
 }

--- a/src/Equinox.Infra.CrossCutting.IoC/NativeInjectorBootStrapper.cs
+++ b/src/Equinox.Infra.CrossCutting.IoC/NativeInjectorBootStrapper.cs
@@ -54,12 +54,12 @@ namespace Equinox.Infra.CrossCutting.IoC
             // Infra - Data
             services.AddScoped<ICustomerRepository, CustomerRepository>();
             services.AddScoped<IUnitOfWork, UnitOfWork>();
-            services.AddScoped<EquinoxContext>();
+            services.AddDbContext<EquinoxContext>();
 
             // Infra - Data EventSourcing
             services.AddScoped<IEventStoreRepository, EventStoreSQLRepository>();
             services.AddScoped<IEventStore, SqlEventStore>();
-            services.AddScoped<EventStoreSQLContext>();
+            services.AddDbContext<EventStoreSQLContext>();
 
             // Infra - Identity Services
             services.AddTransient<IEmailSender, AuthEmailMessageSender>();


### PR DESCRIPTION
Solution Change services.AddScoped<'EquinoxContext'>(); by services.AddDbContext <'EquinoxContext'> ();

Y services.AddScoped<'EventStoreSQLContext'>(); by services.AddDbContext<'EventStoreSQLContext'>();

in

NativeInjectorBootStrapper.cs

Console:

Start project: Api

Focus project: Data

https://stackoverflow.com/questions/52443441/entity-framwork-core-add-migration-fails