### PR TITLE
Preventing Script Injection

### DIFF
--- a/src/Equinox.Application/EventSourcedNormalizers/CustomerHistory.cs
+++ b/src/Equinox.Application/EventSourcedNormalizers/CustomerHistory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Web;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -39,6 +40,9 @@ namespace Equinox.Application.EventSourcedNormalizers
                     Timestamp = change.Timestamp,
                     Who = change.Who
                 };
+
+                // Remove Possible Script Injection
+                jsSlot.Name = HttpUtility.HtmlEncode(jsSlot.Name);
 
                 list.Add(jsSlot);
                 last = change;

--- a/src/Equinox.Domain/Commands/Validations/CustomerValidation.cs
+++ b/src/Equinox.Domain/Commands/Validations/CustomerValidation.cs
@@ -9,7 +9,8 @@ namespace Equinox.Domain.Commands.Validations
         {
             RuleFor(c => c.Name)
                 .NotEmpty().WithMessage("Please ensure you have entered the Name")
-                .Length(2, 150).WithMessage("The Name must have between 2 and 150 characters");
+                .Length(2, 150).WithMessage("The Name must have between 2 and 150 characters")
+                .Matches("^[a-zA-Z0-9]*$").WithMessage("Special characters are not allowed");
         }
 
         protected void ValidateBirthDate()


### PR DESCRIPTION
Added a new Name Validator or Encode Name prop before returning. I Don't know if it was the correct approach, but the current application already has some Script Injection in the history of some customers. 

Example: http://equinoxproject.azurewebsites.net/customer-management/customer-details/c7055224-ba6f-4a5b-a19c-0cece87c384c
