### PR TITLE
fix: Updating Dockerfiles from .NET 6 to .NET 8

### DIFF
--- a/src/Equinox.Services.Api/Dockerfile
+++ b/src/Equinox.Services.Api/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["src/Equinox.Services.Api/Equinox.Services.Api.csproj", "src/Equinox.Services.Api/"]
 RUN dotnet restore "src/Equinox.Services.Api/Equinox.Services.Api.csproj"

--- a/src/Equinox.UI.Web/Dockerfile
+++ b/src/Equinox.UI.Web/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Equinox.UI.Web/Equinox.UI.Web.csproj", "Equinox.UI.Web/"]
 RUN dotnet restore "Equinox.UI.Web/Equinox.UI.Web.csproj"


### PR DESCRIPTION
# Description

This changes are so simple as the title: Updating Dockerfiles from .NET 6 to .NET 8!