### PR TITLE
Fix IAspNetUser method spelling

### DIFF
--- a/src/Equinox.Infra.CrossCutting.Identity/User/AspNetUser.cs
+++ b/src/Equinox.Infra.CrossCutting.Identity/User/AspNetUser.cs
@@ -19,15 +19,15 @@ namespace Equinox.Infra.CrossCutting.Identity.User
 
         public Guid GetUserId()
         {
-            return IsAutenticated() ? Guid.Parse(_accessor.HttpContext.User.GetUserId()) : Guid.Empty;
+            return IsAuthenticated() ? Guid.Parse(_accessor.HttpContext.User.GetUserId()) : Guid.Empty;
         }
 
         public string GetUserEmail()
         {
-            return IsAutenticated() ? _accessor.HttpContext.User.GetUserEmail() : "";
+            return IsAuthenticated() ? _accessor.HttpContext.User.GetUserEmail() : "";
         }
 
-        public bool IsAutenticated()
+        public bool IsAuthenticated()
         {
             return _accessor.HttpContext.User.Identity.IsAuthenticated;
         }

--- a/src/Equinox.Infra.CrossCutting.Identity/User/IAspNetUser.cs
+++ b/src/Equinox.Infra.CrossCutting.Identity/User/IAspNetUser.cs
@@ -10,7 +10,7 @@ namespace Equinox.Infra.CrossCutting.Identity.User
         string Name { get; }
         Guid GetUserId();
         string GetUserEmail();
-        bool IsAutenticated();
+        bool IsAuthenticated();
         bool IsInRole(string role);
         IEnumerable<Claim> GetUserClaims();
         HttpContext GetHttpContext();


### PR DESCRIPTION
## Summary
- fix naming in `IAspNetUser` for `IsAuthenticated`
- update implementation in `AspNetUser`

## Testing
- `dotnet build Equinox.sln -c Release` *(fails: `dotnet` not found)*